### PR TITLE
Fix API route handler params

### DIFF
--- a/11xtesting/src/app/api/posts/[id]/route.ts
+++ b/11xtesting/src/app/api/posts/[id]/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { getPost, updatePost, deletePost } from '@/lib/db';
 
 export async function GET(
-  req: NextRequest,
+  req: Request,
   { params }: { params: { id: string } }
 ) {
   const post = await getPost(params.id);
@@ -13,7 +13,7 @@ export async function GET(
 }
 
 export async function PUT(
-  req: NextRequest,
+  req: Request,
   { params }: { params: { id: string } }
 ) {
   const data = await req.json();
@@ -26,7 +26,7 @@ export async function PUT(
 }
 
 export async function DELETE(
-  req: NextRequest,
+  req: Request,
   { params }: { params: { id: string } }
 ) {
   await deletePost(params.id);


### PR DESCRIPTION
## Summary
- fix argument types for dynamic post API routes

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module '@prisma/client', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685d4652506c832cb0248a7144f31e70